### PR TITLE
fix(governance): P0-001 — authContext mandatory on ChangeTitle/ChangeTeam (SCEN-001)

### DIFF
--- a/app/api/teams/[id]/chief-of-staff/route.ts
+++ b/app/api/teams/[id]/chief-of-staff/route.ts
@@ -93,10 +93,11 @@ export async function POST(
       // SCEN-001 fix (2026-04-13): Gate 0 requires authContext; this route
       // has already verified the governance password, so it is safe to
       // invoke ChangeTitle with a system-owner authContext.
+      // P0-001 (2026-04-14): authContext is now positional arg 3 on ChangeTitle.
       if (oldCosId && !isChiefOfStaffAnywhere(oldCosId)) {
         try {
           const { ChangeTitle } = await import('@/services/element-management-service')
-          await ChangeTitle(oldCosId, null, { authContext: { isSystemOwner: true as const } })
+          await ChangeTitle(oldCosId, null, { isSystemOwner: true as const })
         } catch (err) {
           console.warn('[governance] Failed ChangeTitle on COS removal:', err instanceof Error ? err.message : err)
         }
@@ -124,9 +125,10 @@ export async function POST(
     // ChangeTitle handles: registry write + role-plugin sync
     // (COS team assignment was already done by updateTeam above)
     // SCEN-001 fix (2026-04-13): Gate 0 requires authContext.
+    // P0-001 (2026-04-14): authContext is now positional arg 3 on ChangeTitle.
     try {
       const { ChangeTitle } = await import('@/services/element-management-service')
-      await ChangeTitle(cosAgentId, 'chief-of-staff', { authContext: { isSystemOwner: true as const } })
+      await ChangeTitle(cosAgentId, 'chief-of-staff', { isSystemOwner: true as const })
     } catch (err) {
       console.warn('[governance] Failed ChangeTitle for COS:', err instanceof Error ? err.message : err)
     }

--- a/app/api/teams/[id]/route.ts
+++ b/app/api/teams/[id]/route.ts
@@ -67,8 +67,15 @@ export async function PUT(
     }
 
     // Auto-title transitions: delegate to ChangeTeam for membership changes
+    // P0-001 (2026-04-14): ChangeTeam now requires authContext (positional
+    // arg 3). It propagates to ChangeTitle internally. Before this fix the
+    // PATCH /api/teams/{id} route silently failed to title newly added
+    // agents (BUG-002 root cause) because ChangeTeam accepted an unused
+    // `_authContext` and called ChangeTitle with no auth.
     if (safeBody.agentIds !== undefined) {
       const { ChangeTeam } = await import('@/services/element-management-service')
+      const { buildAuthContext } = await import('@/lib/agent-auth')
+      const changeTeamAuth = buildAuthContext(auth)
       const newAgentIds: string[] = result.data?.team?.agentIds ?? []
       const oldSet = new Set<string>(oldAgentIds)
       const newSet = new Set<string>(newAgentIds)
@@ -76,7 +83,7 @@ export async function PUT(
       for (const agentId of newAgentIds) {
         if (!oldSet.has(agentId)) {
           try {
-            await ChangeTeam(agentId, { teamId: id, role: 'member' })
+            await ChangeTeam(agentId, { teamId: id, role: 'member' }, changeTeamAuth)
           } catch (err: unknown) {
             console.error(`[team PUT] ChangeTeam(add) failed for agent ${agentId}:`, err)
           }
@@ -86,7 +93,7 @@ export async function PUT(
       for (const agentId of oldAgentIds) {
         if (!newSet.has(agentId)) {
           try {
-            await ChangeTeam(agentId, { teamId: null })
+            await ChangeTeam(agentId, { teamId: null }, changeTeamAuth)
           } catch (err: unknown) {
             console.error(`[team PUT] ChangeTeam(remove) failed for agent ${agentId}:`, err)
           }

--- a/services/agents-core-service.ts
+++ b/services/agents-core-service.ts
@@ -715,8 +715,9 @@ export async function updateAgentById(id: string, body: UpdateAgentRequest, requ
     if (oldTitle !== newTitle) {
       try {
         const { ChangeTitle } = await import('@/services/element-management-service')
+        // P0-001 (2026-04-14): authContext is now positional arg 3 on ChangeTitle.
         const ac = authContext || { agentId: requestingAgentId || undefined, isSystemOwner: !requestingAgentId }
-        const titleResult = await ChangeTitle(id, newTitle, { authContext: ac })
+        const titleResult = await ChangeTitle(id, newTitle, ac)
         if (!titleResult.success) console.warn('[agents] ChangeTitle failed:', titleResult.error)
         anyChangeExecuted = true
       } catch (err) {

--- a/services/element-management-service.ts
+++ b/services/element-management-service.ts
@@ -696,13 +696,22 @@ export async function InstallElement(
         const { getAgent: getAgentPG04 } = await import('@/lib/agent-registry')
         const agentPG04 = getAgentPG04(desired.agentId)
         const title = (agentPG04?.governanceTitle || 'autonomous').toLowerCase()
+        // P0-001: ChangeTitle now requires a non-optional authContext. PG04 is
+        // an internal self-repair triggered by an InstallElement uninstall.
+        // InstallElement does not receive an authContext parameter, so we
+        // construct a system-owner context with a descriptive audit reason.
+        // This is SAFE: InstallElement is only invoked from already-authorized
+        // code paths (ChangePlugin, ChangeTitle), and PG04 is a defensive
+        // housekeeping step that maintains R11 invariants.
+        const { buildSystemAuthContext } = await import('@/lib/agent-auth')
+        const pg04AuthContext: AuthContext = buildSystemAuthContext('pg04-title-plugin-repair')
         if (title !== 'autonomous') {
           // Agent has a title that requires a role-plugin — reinstall the default
           const defaultPlugin = TITLE_PLUGIN_MAP[title]
           if (defaultPlugin && defaultPlugin !== name) {
             ops.push(`PG04: R11 violation — agent has title "${title}" but lost role-plugin "${name}". Reinstalling default "${defaultPlugin}" via ChangeTitle.`)
             // ChangeTitle handles the full role-plugin install pipeline
-            const titleResult = await ChangeTitle(desired.agentId, title)
+            const titleResult = await ChangeTitle(desired.agentId, title, pg04AuthContext)
             if (titleResult.success) {
               ops.push(`PG04: ChangeTitle restored default plugin "${defaultPlugin}" (${titleResult.operations.length} sub-gates)`)
             } else {
@@ -711,7 +720,7 @@ export async function InstallElement(
           } else if (defaultPlugin === name) {
             // The uninstalled plugin WAS the default — revert to AUTONOMOUS
             ops.push(`PG04: Uninstalled the default plugin for title "${title}" — reverting agent to AUTONOMOUS`)
-            const titleResult = await ChangeTitle(desired.agentId, 'autonomous')
+            const titleResult = await ChangeTitle(desired.agentId, 'autonomous', pg04AuthContext)
             ops.push(titleResult.success
               ? `PG04: Agent reverted to AUTONOMOUS`
               : `PG04: WARN — Revert to AUTONOMOUS failed: ${titleResult.error}`)
@@ -1390,11 +1399,27 @@ const STANDALONE_TITLES: ReadonlySet<string> = new Set([
 // Singleton titles (only one agent can hold this on the host/team)
 const SINGLETON_TEAM_TITLES: ReadonlySet<string> = new Set(['chief-of-staff', 'orchestrator'])
 
+/**
+ * Change the governance title of an agent.
+ *
+ * SECURITY INVARIANT (P0-001, SCEN-001): `authContext` is REQUIRED as a
+ * positional argument — never optional, never inside an options bag. This
+ * is a compile-time guarantee: TypeScript rejects any call site that forgets
+ * to pass it. If someone bypasses the type system (`any`, `as unknown`, etc.)
+ * the runtime Gate 0 check throws hard instead of returning a soft error that
+ * could be swallowed by a caller's try/catch.
+ *
+ * Why this matters: BUG-002 during SCEN-001 was caused by internal callers
+ * (notably `ChangeTeam`'s auto-title logic) calling ChangeTitle without
+ * authContext. The old soft-return made the failure look like a console.warn
+ * instead of a propagated error, leaving agents in an inconsistent state
+ * (added to team.agentIds but never titled).
+ */
 export async function ChangeTitle(
   agentId: string,
   newTitle: string | null,
+  authContext: AuthContext,
   options?: {
-    authContext?: AuthContext,
     teamIds?: string[]
     skipPluginSync?: boolean
     skipRestart?: boolean
@@ -1414,13 +1439,23 @@ export async function ChangeTitle(
     restartNeeded: false,
   }
 
+  // ── GATE 0 (pre-try, hard throw): Belt-and-braces runtime check ──
+  // Even though TypeScript makes authContext required, some call sites use
+  // `any` / dynamic imports / untyped wrappers. If ChangeTitle is ever called
+  // with `undefined as any`, throw LOUDLY instead of soft-failing into a
+  // try/catch that the caller silently drops. This closes BUG-002 at runtime.
+  if (!authContext) {
+    throw new Error(
+      '[ChangeTitle] FATAL: authContext is required (P0-001). ' +
+      'This is a programmer error — every ChangeTitle caller must provide ' +
+      'an AuthContext. Internal callers should use buildSystemAuthContext(reason). ' +
+      'See services/element-management-service.ts:ChangeTitle for the signature.'
+    )
+  }
+
   try {
     // ── GATE 0: Authorization (change-title: MANAGER/COS only, never self) ──
-    if (!options?.authContext) {
-      result.error = 'authContext is mandatory for ChangeTitle (security invariant)'
-      return result
-    }
-    const g0err = await gate0Auth('change-title', agentId, options.authContext, ops)
+    const g0err = await gate0Auth('change-title', agentId, authContext, ops)
     if (g0err) { result.error = g0err; return result }
 
     // ── GATE 1: Validate title value ─────────────────────────
@@ -2868,10 +2903,24 @@ export async function ChangeTeam(
     teamId: string | null  // null = remove from all teams
     role?: string           // 'member' | 'chief-of-staff' | 'orchestrator' | 'architect' | 'integrator'
   },
-  _authContext?: AuthContext,
+  authContext: AuthContext,
 ): Promise<ChangeResult> {
   const ops: string[] = []
   const result: ChangeResult = { success: false, operations: ops, restartNeeded: false }
+
+  // P0-001 (SCEN-001 BUG-002): ChangeTeam must propagate authContext to its
+  // downstream ChangeTitle calls. Previously, authContext was accepted but
+  // ignored (prefixed `_authContext`), causing auto-title to silently fail
+  // with "authContext is mandatory" and leaving agents titleless in the team
+  // registry. Making authContext required here matches ChangeTitle's contract
+  // and forces every ChangeTeam caller to provide it.
+  if (!authContext) {
+    throw new Error(
+      '[ChangeTeam] FATAL: authContext is required (P0-001). ' +
+      'ChangeTeam propagates this to ChangeTitle, and ChangeTitle rejects ' +
+      'missing authContext at Gate 0. Every caller must provide an AuthContext.'
+    )
+  }
 
   try {
     // ── G01: Validate agent exists ────────────────────────────
@@ -2941,7 +2990,12 @@ export async function ChangeTeam(
       ops.push(`G04c: Removed agent from team "${currentTeam.name}" agentIds`)
 
       // G04d: Revert title to AUTONOMOUS
-      const titleResult = await ChangeTitle(agentId, 'autonomous')
+      // P0-001: Forward authContext so ChangeTitle Gate 0 doesn't reject the
+      // downstream title transition. Before this fix, ChangeTitle returned
+      // "authContext is mandatory for ChangeTitle (security invariant)" and
+      // the registry was left inconsistent (agent removed from team.agentIds
+      // but title never reverted).
+      const titleResult = await ChangeTitle(agentId, 'autonomous', authContext)
       if (!titleResult.success) {
         ops.push(`G04d: WARN — ChangeTitle to AUTONOMOUS failed: ${titleResult.error}`)
       } else {
@@ -2980,8 +3034,13 @@ export async function ChangeTeam(
     }
 
     // G07: Set title
+    // P0-001: Forward authContext — this was THE original BUG-002 site.
+    // Before the fix, ChangeTitle was called with no authContext on the add-
+    // to-team auto-title path, so the team got the agentId but the agent was
+    // never promoted to MEMBER. The UI then showed "unassigned title" while
+    // teams.json claimed the agent was in the team.
     const effectiveRole = desired.role || 'member'
-    const titleResult = await ChangeTitle(agentId, effectiveRole)
+    const titleResult = await ChangeTitle(agentId, effectiveRole, authContext)
     if (!titleResult.success) {
       ops.push(`G07: WARN — ChangeTitle to ${effectiveRole} failed: ${titleResult.error}`)
     } else {
@@ -3828,14 +3887,13 @@ export async function DeleteTeam(
       for (const agentId of agentsToRevert) {
         try {
           // BUG-002 fix (SCEN-005): ChangeTitle requires authContext as a security
-          // invariant. Without it the call returns "authContext is mandatory" and
-          // the COS/Member never reverts to AUTONOMOUS — the team gets deleted but
+          // invariant. Without it the call throws "authContext is required (P0-001)"
+          // and the COS/Member never reverts to AUTONOMOUS — the team gets deleted but
           // its former agents retain their titles AND their role-plugins. Pass
-          // through the DeleteTeam authContext so ChangeTitle treats this revert
-          // as an already-authorized governance operation.
-          const titleResult = await ChangeTitle(agentId, 'autonomous', {
-            authContext: options.authContext,
-          })
+          // through the DeleteTeam authContext (now positional arg 3 per P0-001)
+          // so ChangeTitle treats this revert as an already-authorized governance
+          // operation. G00 above already asserted options.authContext is non-null.
+          const titleResult = await ChangeTitle(agentId, 'autonomous', options!.authContext!)
           if (titleResult.success) {
             ops.push(`G03: Agent ${agentId.substring(0, 8)} → AUTONOMOUS`)
           } else {
@@ -4012,8 +4070,9 @@ export async function DeleteAgent(
       const { isManager: checkManager } = await import('@/lib/governance')
       if (checkManager(agentId)) {
         ops.push('G02: Agent is MANAGER — auto-demoting to AUTONOMOUS before deletion')
-        const titleResult = await ChangeTitle(agentId, 'autonomous', {
-          authContext: options?.authContext,
+        // P0-001: authContext is now positional arg 3. G00 above already
+        // asserted it is non-null, so the non-null assertion is safe here.
+        const titleResult = await ChangeTitle(agentId, 'autonomous', options!.authContext!, {
           skipRestart: true,  // No point restarting — we're about to delete
         })
         if (!titleResult.success) {
@@ -4593,8 +4652,8 @@ export async function CreateAgent(
       TEAM_REQUIRED_TITLES_G06.has(desired.governanceTitle)
 
     if (desired.governanceTitle && desired.governanceTitle !== 'autonomous' && !titleNeedsTeamFirst) {
-      const titleResult = await ChangeTitle(agent.id, desired.governanceTitle, {
-        authContext: desired.authContext,
+      // P0-001: authContext is now positional arg 3 on ChangeTitle.
+      const titleResult = await ChangeTitle(agent.id, desired.governanceTitle, desired.authContext, {
         githubRepo: desired.githubRepo,
       })
       if (!titleResult.success) {
@@ -4620,7 +4679,9 @@ export async function CreateAgent(
 
     // ── G07: Add to team if requested ────────────────────────
     if (desired.teamId) {
-      const teamResult = await ChangeTeam(agent.id, { teamId: desired.teamId })
+      // P0-001: ChangeTeam now requires authContext (positional arg 3). It
+      // propagates to the downstream ChangeTitle call inside ChangeTeam.
+      const teamResult = await ChangeTeam(agent.id, { teamId: desired.teamId }, desired.authContext)
       if (!teamResult.success) {
         ops.push(`G07: WARN — ChangeTeam failed: ${teamResult.error}`)
       } else {
@@ -4628,15 +4689,16 @@ export async function CreateAgent(
         result.restartNeeded = result.restartNeeded || teamResult.restartNeeded
       }
 
-      // G07b: ChangeTeam tries to auto-assign "member" title, but that internal
-      // ChangeTitle call lacks authContext and FAILS silently at Gate 0.
-      // ALWAYS re-apply the requested title after team join (including 'member')
-      // to guarantee governanceTitle is persisted to the registry.
+      // G07b: ChangeTeam auto-assigns 'member' title when an agent is added
+      // to a team. P0-001 fixed the silent authContext bug, so ChangeTeam now
+      // successfully applies 'member'. We still re-apply the requested title
+      // here because the wizard may request a non-member title (architect,
+      // integrator, etc.) that ChangeTeam wouldn't assign on its own.
       // This fixes SCEN-020 BUG-001 (registry missing governanceTitle after wizard
       // creation) and BUG-022 (non-member titles being ignored).
       if (desired.governanceTitle && desired.governanceTitle !== 'autonomous') {
-        const retitleResult = await ChangeTitle(agent.id, desired.governanceTitle, {
-          authContext: desired.authContext,
+        // P0-001: authContext is now positional arg 3.
+        const retitleResult = await ChangeTitle(agent.id, desired.governanceTitle, desired.authContext, {
           githubRepo: desired.githubRepo,
         })
         if (!retitleResult.success) {

--- a/services/governance-service.ts
+++ b/services/governance-service.ts
@@ -85,9 +85,10 @@ export async function setManagerRole(params: {
   // system owner (enforced at the POST /api/governance/manager route via
   // enforceSystemOwner). Since password verification has just succeeded
   // above, it is safe to pass a system-owner authContext to ChangeTitle.
-  // Without this, ChangeTitle Gate 0 rejects with "authContext is
-  // mandatory for ChangeTitle (security invariant)" and the UI shows
-  // "Title change failed" even though the caller is authenticated.
+  // P0-001 (2026-04-14): authContext is now positional arg 3 — no longer
+  // wrapped in an options bag. The original bug class this change prevents:
+  // a caller forgets the options bag entirely and ChangeTitle silently
+  // returns an error that gets swallowed by a try/catch.
   const systemOwnerAuthContext = { isSystemOwner: true as const }
 
   // agentId === null means "remove manager"
@@ -95,7 +96,7 @@ export async function setManagerRole(params: {
     const oldManagerId = config.managerId
     if (oldManagerId) {
       const { ChangeTitle } = await import('@/services/element-management-service')
-      const titleResult = await ChangeTitle(oldManagerId, null, { authContext: systemOwnerAuthContext })
+      const titleResult = await ChangeTitle(oldManagerId, null, systemOwnerAuthContext)
       if (!titleResult.success) {
         console.warn('[governance] ChangeTitle failed on manager removal:', titleResult.error)
       }
@@ -116,7 +117,7 @@ export async function setManagerRole(params: {
 
   // ChangeTitle handles: governance.json, agent registry, role-plugin sync
   const { ChangeTitle } = await import('@/services/element-management-service')
-  const titleResult = await ChangeTitle(agentId, 'manager', { authContext: systemOwnerAuthContext })
+  const titleResult = await ChangeTitle(agentId, 'manager', systemOwnerAuthContext)
   if (!titleResult.success) {
     return { error: titleResult.error || 'Failed to assign manager title', status: 500 }
   }

--- a/services/headless-router.ts
+++ b/services/headless-router.ts
@@ -2296,10 +2296,11 @@ const routes: Route[] = [
 
         // ChangeTitle handles: registry + role-plugin cleanup (only if no longer COS anywhere)
         // SCEN-001 fix (2026-04-13): Gate 0 requires authContext.
+        // P0-001 (2026-04-14): authContext is now positional arg 3.
         if (oldCosId && !isChiefOfStaffAnywhere(oldCosId)) {
           try {
             const { ChangeTitle } = await import('@/services/element-management-service')
-            await ChangeTitle(oldCosId, null, { authContext: { isSystemOwner: true as const } })
+            await ChangeTitle(oldCosId, null, { isSystemOwner: true as const })
           } catch (err) {
             console.warn('[governance] Failed ChangeTitle on COS removal:', err instanceof Error ? err.message : err)
           }
@@ -2331,9 +2332,10 @@ const routes: Route[] = [
 
       // ChangeTitle handles: registry write + role-plugin sync
       // SCEN-001 fix (2026-04-13): Gate 0 requires authContext.
+      // P0-001 (2026-04-14): authContext is now positional arg 3.
       try {
         const { ChangeTitle } = await import('@/services/element-management-service')
-        await ChangeTitle(cosAgentId, 'chief-of-staff', { authContext: { isSystemOwner: true as const } })
+        await ChangeTitle(cosAgentId, 'chief-of-staff', { isSystemOwner: true as const })
       } catch (err) {
         console.warn('[governance] Failed ChangeTitle for COS:', err instanceof Error ? err.message : err)
       }

--- a/services/teams-service.ts
+++ b/services/teams-service.ts
@@ -262,10 +262,11 @@ export async function createNewTeam(params: CreateTeamParams): Promise<ServiceRe
     const systemOwnerAuthContext = { isSystemOwner: true as const }
 
     // Assign COS title + role-plugin via ChangeTitle pipeline.
+    // P0-001 (2026-04-14): authContext is now positional arg 3 on ChangeTitle.
     if (cosId) {
       try {
         const { ChangeTitle } = await import('@/services/element-management-service')
-        await ChangeTitle(cosId, 'chief-of-staff', { authContext: systemOwnerAuthContext })
+        await ChangeTitle(cosId, 'chief-of-staff', systemOwnerAuthContext)
       } catch (err) {
         console.warn('[teams] Failed ChangeTitle for COS:', err instanceof Error ? err.message : err)
       }
@@ -280,7 +281,7 @@ export async function createNewTeam(params: CreateTeamParams): Promise<ServiceRe
     for (const id of agentIdsToTitle) {
       try {
         const { ChangeTitle } = await import('@/services/element-management-service')
-        await ChangeTitle(id, 'member', { authContext: systemOwnerAuthContext })
+        await ChangeTitle(id, 'member', systemOwnerAuthContext)
       } catch (err) {
         console.warn(`[teams] Failed ChangeTitle to MEMBER for agent ${id}:`, err instanceof Error ? err.message : err)
       }
@@ -291,7 +292,7 @@ export async function createNewTeam(params: CreateTeamParams): Promise<ServiceRe
       try {
         await updateTeam(team.id, { orchestratorId: params.orchestratorId }, managerId)
         const { ChangeTitle } = await import('@/services/element-management-service')
-        await ChangeTitle(params.orchestratorId, 'orchestrator', { authContext: systemOwnerAuthContext })
+        await ChangeTitle(params.orchestratorId, 'orchestrator', systemOwnerAuthContext)
       } catch (err) {
         console.warn('[teams] Failed to set orchestrator:', err instanceof Error ? err.message : err)
       }
@@ -392,6 +393,7 @@ export async function updateTeamById(id: string, params: UpdateTeamParams): Prom
     const systemOwnerAuthContextForUpdate = { isSystemOwner: true as const }
 
     // Strip titles from removed agents (team-bound titles are meaningless outside teams)
+    // P0-001 (2026-04-14): authContext is now positional arg 3 on ChangeTitle.
     if (newAgentIds !== undefined) {
       const removedAgentIds = oldAgentIds.filter(aid => !newAgentIds.includes(aid))
       if (removedAgentIds.length > 0) {
@@ -399,7 +401,7 @@ export async function updateTeamById(id: string, params: UpdateTeamParams): Prom
         for (const removedId of removedAgentIds) {
           try {
             // Reverts to AUTONOMOUS, uninstalls role-plugin
-            await ChangeTitle(removedId, null, { authContext: systemOwnerAuthContextForUpdate })
+            await ChangeTitle(removedId, null, systemOwnerAuthContextForUpdate)
           } catch (err) {
             console.warn(`[teams] Failed to strip title from removed agent ${removedId}:`, err instanceof Error ? err.message : err)
           }
@@ -416,7 +418,7 @@ export async function updateTeamById(id: string, params: UpdateTeamParams): Prom
             const agent = getAgent(addedId)
             // Only auto-title if agent doesn't already have a team-specific title
             if (!agent?.governanceTitle || agent.governanceTitle === 'autonomous') {
-              await ChangeTitle(addedId, 'member', { authContext: systemOwnerAuthContextForUpdate })
+              await ChangeTitle(addedId, 'member', systemOwnerAuthContextForUpdate)
             }
           } catch (err) {
             console.warn(`[teams] Failed to auto-title added agent ${addedId}:`, err instanceof Error ? err.message : err)
@@ -508,11 +510,12 @@ export async function deleteTeamById(id: string, requestingAgentId?: string, pas
     // ChangeTitle Gate 0 doesn't silently reject the revert. deleteTeamById
     // itself is marked @deprecated, but the fix is kept for safety while
     // the DeleteTeam pipeline is still being adopted.
+    // P0-001 (2026-04-14): authContext is now positional arg 3 on ChangeTitle.
     const systemOwnerAuthContextForDelete = { isSystemOwner: true as const }
     const { ChangeTitle } = await import('@/services/element-management-service')
     for (const agentId of uniqueAgents) {
       try {
-        await ChangeTitle(agentId, 'autonomous', { authContext: systemOwnerAuthContextForDelete })
+        await ChangeTitle(agentId, 'autonomous', systemOwnerAuthContextForDelete)
       } catch (err) {
         console.warn(`[deleteTeamById] ChangeTitle to AUTONOMOUS failed for ${agentId}:`, err instanceof Error ? err.message : err)
       }

--- a/tests/integration/governance-title-auth.test.ts
+++ b/tests/integration/governance-title-auth.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Regression test for SCEN-001 P0-001: authContext passed to ChangeTitle
+ *
+ * BUG (pre-fix): `setManagerRole` called `ChangeTitle(agentId, 'manager')`
+ * without passing an `authContext`. Gate 0 of ChangeTitle rejected the call
+ * with "authContext is mandatory for ChangeTitle (security invariant)", so
+ * every "Assign MANAGER" click in the UI silently failed.
+ *
+ * This test locks the fix in place: `setManagerRole` MUST pass a
+ * system-owner authContext to `ChangeTitle` on both promotion (assign) and
+ * demotion (remove) paths. If a future refactor drops the authContext, this
+ * test fails at the compile-time mock assertion.
+ *
+ * See: tests/scenarios/reports/scenario_proposed-improvements_001_20260413T214617Z.md § "P0: Commit & ship the authContext fixes"
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { makeAgent } from '../test-utils/fixtures'
+
+// ============================================================================
+// Mocks — vi.hoisted() ensures availability before vi.mock() runs
+// ============================================================================
+
+const {
+  mockGovernanceLib,
+  mockAgentRegistry,
+  mockRateLimit,
+  mockChangeTitle,
+  mockTeamRegistry,
+  mockFileLock,
+  mockManagerTrust,
+  mockNotificationService,
+  mockTransferRegistry,
+  mockMessageFilter,
+  mockValidation,
+} = vi.hoisted(() => ({
+  mockGovernanceLib: {
+    loadGovernance: vi.fn(),
+    verifyPassword: vi.fn(),
+    setManager: vi.fn(),
+    removeManager: vi.fn(),
+    setPassword: vi.fn(),
+    setUserName: vi.fn(),
+    isManager: vi.fn(() => false),
+    isChiefOfStaffAnywhere: vi.fn(() => false),
+    getManagerId: vi.fn(() => null),
+  },
+  mockAgentRegistry: {
+    getAgent: vi.fn(),
+    loadAgents: vi.fn(() => []),
+    updateAgent: vi.fn(),
+  },
+  mockRateLimit: {
+    checkAndRecordAttempt: vi.fn(() => ({ allowed: true, retryAfterMs: 0 })),
+    resetRateLimit: vi.fn(),
+  },
+  // Spy on ChangeTitle — this is the assertion surface for this regression test
+  mockChangeTitle: vi.fn(),
+  mockTeamRegistry: {
+    loadTeams: vi.fn(() => []),
+    saveTeams: vi.fn(),
+    TeamValidationException: class extends Error {
+      code: number
+      constructor(message: string, code: number) {
+        super(message)
+        this.name = 'TeamValidationException'
+        this.code = code
+      }
+    },
+  },
+  mockFileLock: {
+    acquireLock: vi.fn(() => Promise.resolve(() => {})),
+    withLock: vi.fn((_name: string, fn: () => unknown) => Promise.resolve(fn())),
+  },
+  mockManagerTrust: {
+    addTrustedManager: vi.fn(),
+    removeTrustedManager: vi.fn(),
+    getTrustedManagers: vi.fn(() => []),
+  },
+  mockNotificationService: {
+    notifyAgent: vi.fn(),
+  },
+  mockTransferRegistry: {
+    loadTransfers: vi.fn(() => []),
+    createTransferRequest: vi.fn(),
+    getTransferRequest: vi.fn(),
+    resolveTransferRequest: vi.fn(),
+    revertTransferToPending: vi.fn(),
+    getPendingTransfersForAgent: vi.fn(() => []),
+  },
+  mockMessageFilter: {
+    checkMessageAllowed: vi.fn(() => true),
+  },
+  mockValidation: {
+    isValidUuid: vi.fn(() => true),
+  },
+}))
+
+vi.mock('@/lib/governance', () => mockGovernanceLib)
+vi.mock('@/lib/agent-registry', () => mockAgentRegistry)
+vi.mock('@/lib/rate-limit', () => mockRateLimit)
+vi.mock('@/lib/team-registry', () => mockTeamRegistry)
+vi.mock('@/lib/file-lock', () => mockFileLock)
+vi.mock('@/lib/manager-trust', () => mockManagerTrust)
+vi.mock('@/lib/notification-service', () => mockNotificationService)
+vi.mock('@/lib/transfer-registry', () => mockTransferRegistry)
+vi.mock('@/lib/message-filter', () => mockMessageFilter)
+vi.mock('@/lib/validation', () => mockValidation)
+
+// Mock element-management-service: setManagerRole dynamically imports ChangeTitle
+// from this module. vi.mock intercepts dynamic imports the same as static ones.
+vi.mock('@/services/element-management-service', () => ({
+  ChangeTitle: (...args: unknown[]) => mockChangeTitle(...args),
+}))
+
+// ============================================================================
+// Import module under test (after mocks)
+// ============================================================================
+
+import { setManagerRole } from '@/services/governance-service'
+
+// ============================================================================
+// Setup
+// ============================================================================
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Default: password is set (caller can pass any non-empty password)
+  mockGovernanceLib.loadGovernance.mockReturnValue({
+    passwordHash: 'hashed:test-password',
+    managerId: null,
+  })
+  mockGovernanceLib.verifyPassword.mockResolvedValue(true)
+  // Default: rate limit allows
+  mockRateLimit.checkAndRecordAttempt.mockReturnValue({ allowed: true, retryAfterMs: 0 })
+  // Default: ChangeTitle succeeds
+  mockChangeTitle.mockResolvedValue({
+    success: true,
+    agentId: 'agent-1',
+    oldTitle: null,
+    newTitle: 'manager',
+    operations: [],
+    installedPlugin: null,
+    uninstalledPlugin: null,
+    restartNeeded: false,
+  })
+})
+
+// ============================================================================
+// Tests — SCEN-001 P0 regression
+// ============================================================================
+
+describe('setManagerRole (regression: SCEN-001 P0 — authContext propagation)', () => {
+  it('passes authContext as positional arg 3 to ChangeTitle when promoting to MANAGER', async () => {
+    /** Promoting a MANAGER MUST pass a system-owner authContext to ChangeTitle.
+     * P0-001 (2026-04-14): authContext is now a REQUIRED positional argument
+     * on ChangeTitle — not an options field. This prevents the silent bug
+     * class where callers forget the options bag entirely. */
+    const agent = makeAgent({ id: 'agent-1', name: 'jack-bot' })
+    mockAgentRegistry.getAgent.mockReturnValue(agent)
+
+    const result = await setManagerRole({ agentId: 'agent-1', password: 'test-password' })
+
+    expect(result.status).toBe(200)
+    expect(result.data?.success).toBe(true)
+    expect(result.data?.managerId).toBe('agent-1')
+
+    // The core assertion: ChangeTitle was called with authContext as arg 3
+    expect(mockChangeTitle).toHaveBeenCalledTimes(1)
+    const [calledAgentId, calledNewTitle, calledAuthContext] = mockChangeTitle.mock.calls[0] as [
+      string,
+      string | null,
+      { isSystemOwner?: boolean } | undefined,
+    ]
+    expect(calledAgentId).toBe('agent-1')
+    expect(calledNewTitle).toBe('manager')
+    expect(calledAuthContext).toBeDefined()
+    expect(calledAuthContext?.isSystemOwner).toBe(true)
+  })
+
+  it('passes authContext as positional arg 3 to ChangeTitle when demoting the current MANAGER', async () => {
+    /** Demoting a MANAGER (agentId === null) MUST also pass a system-owner
+     * authContext — same Gate 0 invariant applies on removal. */
+    const currentManager = makeAgent({ id: 'jack-bot-id', name: 'jack-bot' })
+    mockGovernanceLib.loadGovernance.mockReturnValue({
+      passwordHash: 'hashed:test-password',
+      managerId: 'jack-bot-id',
+    })
+    mockAgentRegistry.getAgent.mockReturnValue(currentManager)
+
+    const result = await setManagerRole({ agentId: null, password: 'test-password' })
+
+    expect(result.status).toBe(200)
+    expect(result.data?.success).toBe(true)
+    expect(result.data?.managerId).toBeNull()
+
+    // The core assertion: ChangeTitle was called with authContext as arg 3 on removal too
+    expect(mockChangeTitle).toHaveBeenCalledTimes(1)
+    const [calledAgentId, calledNewTitle, calledAuthContext] = mockChangeTitle.mock.calls[0] as [
+      string,
+      string | null,
+      { isSystemOwner?: boolean } | undefined,
+    ]
+    expect(calledAgentId).toBe('jack-bot-id')
+    expect(calledNewTitle).toBeNull()
+    expect(calledAuthContext).toBeDefined()
+    expect(calledAuthContext?.isSystemOwner).toBe(true)
+  })
+
+  it('propagates ChangeTitle failure to the caller (no silent swallow)', async () => {
+    /** If ChangeTitle fails on promotion, setManagerRole MUST return a 500
+     * error — it cannot silently succeed. This protects against the
+     * scenario where Gate 0 rejects the call and the UI shows "success". */
+    const agent = makeAgent({ id: 'agent-2', name: 'bad-agent' })
+    mockAgentRegistry.getAgent.mockReturnValue(agent)
+    mockChangeTitle.mockResolvedValue({
+      success: false,
+      agentId: 'agent-2',
+      oldTitle: null,
+      newTitle: 'manager',
+      operations: [],
+      installedPlugin: null,
+      uninstalledPlugin: null,
+      restartNeeded: false,
+      error: 'some downstream failure',
+    })
+
+    const result = await setManagerRole({ agentId: 'agent-2', password: 'test-password' })
+
+    expect(result.status).toBe(500)
+    expect(result.error).toMatch(/downstream failure/i)
+  })
+
+  it('rejects when governance password is missing from the request', async () => {
+    /** Sanity check: password is required. This path does NOT call ChangeTitle. */
+    const result = await setManagerRole({ agentId: 'agent-1', password: '' })
+
+    expect(result.status).toBe(400)
+    expect(mockChangeTitle).not.toHaveBeenCalled()
+  })
+
+  it('rejects when governance password is wrong', async () => {
+    /** Sanity check: bad password is rejected before ChangeTitle is invoked. */
+    mockGovernanceLib.verifyPassword.mockResolvedValue(false)
+
+    const result = await setManagerRole({ agentId: 'agent-1', password: 'wrong-password' })
+
+    expect(result.status).toBe(401)
+    expect(mockChangeTitle).not.toHaveBeenCalled()
+  })
+
+  it('rejects when target agent does not exist', async () => {
+    /** Sanity check: missing agent short-circuits before ChangeTitle. */
+    mockAgentRegistry.getAgent.mockReturnValue(undefined)
+
+    const result = await setManagerRole({ agentId: 'ghost-agent', password: 'test-password' })
+
+    expect(result.status).toBe(404)
+    expect(mockChangeTitle).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Closes the "silent auto-title failure" class of bugs by making `authContext` a **required positional argument** on `ChangeTitle` and `ChangeTeam`. Source: **SCEN-001 P0-001** from the 2026-04-13/14 overnight scenario batch.

**Do NOT auto-merge.** Review first.

## Root cause (BUG-002 from SCEN-001)

`ChangeTitle` accepted `authContext` inside an optional options bag, and `ChangeTeam` accepted an underscore-prefixed `_authContext` that it silently ignored. When `ChangeTeam` called `ChangeTitle` without auth, Gate 0 soft-returned `"authContext is mandatory"` and the caller's `try/catch` swallowed it as a `console.warn`.

Net effect: adding an agent to a team via `PATCH /api/teams/{id}` wrote the new `agentId` to `teams.json` but the downstream auto-title step silently no-oped, leaving the registry in an inconsistent state.

## Structural fix

- **ChangeTitle**: `authContext` is now a required positional argument (arg 3). Gate 0 is upgraded from soft-return to hard-throw.
- **ChangeTeam**: `authContext` is now a required positional argument and is forwarded to every downstream `ChangeTitle` call. The `_authContext` ghost parameter is gone.

## Call sites updated (~25 total)

- `services/element-management-service.ts` — ChangeTitle signature + 8 internal calls (PG04 x2, G04d ChangeTeam remove, G07 ChangeTeam add, G03 DeleteTeam, G02 DeleteAgent, G06 CreateAgent, G07b CreateAgent re-apply)
- `services/headless-router.ts` — 2 COS assign/remove callers
- `services/governance-service.ts` — 2 MANAGER assign/remove callers
- `services/teams-service.ts` — 6 callers (createTeam x3, updateTeamById x2, deleteTeamById x1)
- `services/agents-core-service.ts` — 1 PATCH `/api/agents/{id}` caller
- `app/api/teams/[id]/chief-of-staff/route.ts` — 2 callers
- `app/api/teams/[id]/route.ts` — 2 `ChangeTeam` callers now use `buildAuthContext(auth)` — this is the **primary BUG-002 source site**

## Additional fix

`CreateAgent` G07 was also calling `ChangeTeam` without `authContext` — a second instance of the same silent-failure pattern affecting wizard-driven member auto-titling. Fixed in the same commit.

## Regression test

`tests/integration/governance-title-auth.test.ts` (cherry-picked from `p0-001-scen-001-authcontext-regression` and updated to match the new positional-arg signature). **6/6 tests pass locally.** Future refactors that drop the `authContext` will fail this test at compile time (TypeScript) and at runtime (vitest spy on `ChangeTitle` arg 3).

## Verification (from session 1, worktree-agent-a76eedfc)

- `npx tsc --noEmit`: PASS (exit 0, zero new errors)
- `yarn build`: PASS (Done in 21.75s)
- `yarn test tests/integration/governance-title-auth.test.ts`: PASS (6/6)
- `yarn test` (full suite): 969 passed / 24 failed — the 24 failures are all pre-existing (cozo-node binary, mock setup issues, unrelated files) and identical to the pre-P0 baseline on `a893721e`

## Test plan
- [ ] Human review of the structural signature change
- [ ] Confirm the regression test fails if any `ChangeTitle` call-site drops `authContext`
- [ ] Sanity check: create team → add agent → verify new agent gets auto-titled (UI path)
- [ ] Re-run `npx tsc --noEmit` + `yarn build` against current `feature/team-governance` tip after rebase
