### PR TITLE
fix(wizard): P0-018-003 — hide celebration on creation failure (SCEN-018)

### DIFF
--- a/components/AgentCreationWizard.tsx
+++ b/components/AgentCreationWizard.tsx
@@ -508,13 +508,25 @@ export default function AgentCreationWizard({ onClose, onComplete }: AgentCreati
             {isCreating ? (
               <div className="flex-1 flex flex-col items-center justify-center p-6">
                 <div className="text-center mb-2">
-                  <h3 className="text-lg font-semibold text-gray-100">
-                    {animationPhase === 'ready' ? 'Your Agent is Ready!' : 'Creating Your Agent'}
+                  {/* P0-018-003: gate celebration on success. creationError (truthy) is
+                      the single source of failure truth — it's set atomically with
+                      setAnimationPhase('error') at line 419-420 and is immune to the
+                      animation timer race that can flip animationPhase back to 'ready'. */}
+                  <h3 className={`text-lg font-semibold ${creationError ? 'text-red-400' : 'text-gray-100'}`}>
+                    {creationError
+                      ? 'Could Not Create Agent'
+                      : animationPhase === 'ready'
+                        ? 'Your Agent is Ready!'
+                        : 'Creating Your Agent'}
                   </h3>
-                  {animationPhase !== 'ready' && <p className="text-sm text-gray-400">{personaName}</p>}
+                  {animationPhase !== 'ready' && !creationError && <p className="text-sm text-gray-400">{personaName}</p>}
                 </div>
                 <CreateAgentAnimation
-                  phase={animationPhase}
+                  // P0-018-003: when creationError is set, force the animation into
+                  // its 'error' phase so the celebratory ReadyAnimation (avatar +
+                  // confetti) can't render even if the background timer race still
+                  // flips animationPhase to 'ready' after the error handler fired.
+                  phase={creationError ? 'error' : animationPhase}
                   agentName={personaName.toLowerCase().replace(/\s+/g, '-')}
                   agentAlias={personaName}
                   avatarUrl={selectedAvatar || getPreviewAvatarUrl(personaName)}


### PR DESCRIPTION
## Summary

Gates the Agent Creation Wizard's Step 7 celebration on success state. When creation fails, the wizard now renders "Could Not Create Agent" + error text instead of the celebratory "Your Agent is Ready!" heading + avatar + confetti alongside the error. Source: **SCEN-018 P0-018-003** from the 2026-04-13/14 overnight scenario batch.

**Do NOT auto-merge.** Review first.

## Root cause

The wizard's Step 7 render block rendered the celebratory heading and `CreateAgentAnimation` component based on `animationPhase === 'ready'`, without consulting the `creationError` state. When the MAINTAINER creation failed (e.g., repo already bound to another agent), the error text was shown by a separate code path, but the celebratory scaffolding was NOT suppressed — producing a confusing mixed success/failure UI.

### The race condition

`creationError` is set **atomically** with `setAnimationPhase('error')` in the error handler (lines 419–420), but a background timer can later flip `animationPhase` back to `'ready'`. Gating only on `animationPhase === 'ready'` would therefore re-show the celebration if the timer race fires after the error handler. Gating on `creationError` (truthy) instead gives a stable, atomic signal that cannot be flipped by the background timer.

## Fix

`components/AgentCreationWizard.tsx` (+16 −4), all inside the Step 7 render block:

1. **Heading** — text color becomes red when `creationError` is truthy; text becomes "Could Not Create Agent" instead of "Your Agent is Ready!"
2. **Sub-label** — hidden when `creationError` is truthy (was only hidden for non-ready phases before)
3. **`CreateAgentAnimation` phase prop** — forced to `'error'` when `creationError` is set, so the celebratory ReadyAnimation (avatar + confetti) can't render even if the timer race flips `animationPhase` back to `'ready'` after the error handler fired

No new imports. No new components. No state changes. The existing error panel at line 547 (which already renders `creationError` text) is untouched.

## What the proposal got wrong

The proposal sketched the fix as `{creationResult.ok ? (...) : (...)}`, but there is **no `creationResult` object in this file**. The error state is a simple string: `const [creationError, setCreationError] = useState('')`. The agent correctly matched the actual codebase shape rather than the proposal sketch.

## Verification

- `npx tsc --noEmit`: **PASS** (exit 0)
- `yarn build`: **PASS** ("Done in 26.98s")
- No new lint warnings introduced

### Pre-existing, out-of-scope warning

There is a Next.js "use client" soft lint at line 124 (`onClose`/`onComplete` props marked as non-serializable) that exists on `feature/team-governance` HEAD and is NOT introduced by this PR. Filing as a separate issue is recommended but out of scope here.

## Test plan

- [ ] Human review of the `creationError` gate logic
- [ ] Reproduce the failure path: try to create a second MAINTAINER bound to an already-taken GitHub repo — the wizard should now show "Could Not Create Agent" + error icon + error text, not the celebratory "Your Agent is Ready!"
- [ ] Confirm the happy path still shows "Your Agent is Ready!" + avatar + confetti when creation succeeds
- [ ] Verify the animation timer race is genuinely neutralized (not tested in this PR — would need a unit test with fake timers)
