### PR TITLE
fix(governance): DeleteTeam must not strip standalone titles + must clear team field (WT-006/7#2 + WT-009#2)

### DIFF
--- a/services/element-management-service.ts
+++ b/services/element-management-service.ts
@@ -3825,24 +3825,65 @@ export async function DeleteTeam(
     ])]
     if (agentsToRevert.length > 0) {
       const { hibernateAgent } = await import('@/services/agents-core-service')
+      // WT-006/7#2 fix: MANAGER and MAINTAINER are STANDALONE titles (they
+      // live outside any team). If such an agent happens to be listed as a
+      // team member (e.g. because the host MANAGER was also added to the
+      // team's agentIds), DeleteTeam must NOT revert their title — only
+      // team-scoped titles (member, chief-of-staff, orchestrator, architect,
+      // integrator) should be reverted to AUTONOMOUS. Filter them out using
+      // STANDALONE_TITLES (which already includes 'autonomous' as a no-op).
+      // Hibernation still applies to every agent in the team regardless of
+      // title — stopping running sessions is correct on team deletion.
+      const { getAgent, updateAgent } = await import('@/lib/agent-registry')
+      const filteredAgentsToRevert: string[] = []
+      const skippedStandalone: string[] = []
+      for (const aid of agentsToRevert) {
+        const a = getAgent(aid)
+        const title = (a?.governanceTitle || 'autonomous').toLowerCase()
+        if (STANDALONE_TITLES.has(title)) {
+          skippedStandalone.push(aid)
+        } else {
+          filteredAgentsToRevert.push(aid)
+        }
+      }
+      if (skippedStandalone.length > 0) {
+        ops.push(`G03: Skipped ${skippedStandalone.length} standalone-title agent(s) (MANAGER/MAINTAINER/already-AUTONOMOUS): ${skippedStandalone.map(a => a.substring(0, 8)).join(', ')}`)
+      }
       for (const agentId of agentsToRevert) {
-        try {
-          // BUG-002 fix (SCEN-005): ChangeTitle requires authContext as a security
-          // invariant. Without it the call returns "authContext is mandatory" and
-          // the COS/Member never reverts to AUTONOMOUS — the team gets deleted but
-          // its former agents retain their titles AND their role-plugins. Pass
-          // through the DeleteTeam authContext so ChangeTitle treats this revert
-          // as an already-authorized governance operation.
-          const titleResult = await ChangeTitle(agentId, 'autonomous', {
-            authContext: options.authContext,
-          })
-          if (titleResult.success) {
-            ops.push(`G03: Agent ${agentId.substring(0, 8)} → AUTONOMOUS`)
-          } else {
-            ops.push(`G03: WARN — ChangeTitle failed for ${agentId.substring(0, 8)}: ${titleResult.error}`)
+        // Only revert team-scoped titles — standalone titles are skipped.
+        const shouldRevertTitle = filteredAgentsToRevert.includes(agentId)
+        if (shouldRevertTitle) {
+          try {
+            // BUG-002 fix (SCEN-005): ChangeTitle requires authContext as a security
+            // invariant. Without it the call returns "authContext is mandatory" and
+            // the COS/Member never reverts to AUTONOMOUS — the team gets deleted but
+            // its former agents retain their titles AND their role-plugins. Pass
+            // through the DeleteTeam authContext so ChangeTitle treats this revert
+            // as an already-authorized governance operation.
+            const titleResult = await ChangeTitle(agentId, 'autonomous', {
+              authContext: options.authContext,
+            })
+            if (titleResult.success) {
+              ops.push(`G03: Agent ${agentId.substring(0, 8)} → AUTONOMOUS`)
+              // WT-009#2 fix: After reverting to AUTONOMOUS, also clear the
+              // agent's `team` field in the registry. Otherwise a zombie
+              // `team: "<old-team-name>"` field remains after the team is
+              // gone, causing confusion in downstream code that reads it
+              // (same pattern as ChangeTeam PG01 at line 2953). Empty string
+              // is used because UpdateAgentRequest.team is typed `string`,
+              // not `string | null` — this matches the existing precedent.
+              try {
+                await updateAgent(agentId, { team: '' })
+                ops.push(`G03: Agent ${agentId.substring(0, 8)} team field cleared`)
+              } catch (err) {
+                ops.push(`G03: WARN — updateAgent team='' failed for ${agentId.substring(0, 8)}: ${err instanceof Error ? err.message : err}`)
+              }
+            } else {
+              ops.push(`G03: WARN — ChangeTitle failed for ${agentId.substring(0, 8)}: ${titleResult.error}`)
+            }
+          } catch (err) {
+            ops.push(`G03: WARN — ChangeTitle exception for ${agentId.substring(0, 8)}: ${err instanceof Error ? err.message : err}`)
           }
-        } catch (err) {
-          ops.push(`G03: WARN — ChangeTitle exception for ${agentId.substring(0, 8)}: ${err instanceof Error ? err.message : err}`)
         }
         // Hibernate the agent via the canonical hibernateAgent pipeline
         // (same code path used by POST /api/agents/[id]/hibernate). This


### PR DESCRIPTION
## Summary

Fixes two related bugs (WT-006/7#2 and WT-009#2) in the DeleteTeam pipeline's G03 gate in `services/element-management-service.ts`. Both are surfaced by the SCEN-006/007/009 scenario reports.

## The bugs

### WT-006/7#2 — DeleteTeam strips standalone titles

The G03 gate iterates over `agentsToRevert` (= `team.agentIds + chiefOfStaffId + orchestratorId`) and calls `ChangeTitle(agentId, 'autonomous', ...)` on each. This is wrong for agents whose current title is **standalone** (`manager` or `maintainer`) — those titles live **outside** any team and must never be stripped by team deletion. Only team-scoped titles (member, chief-of-staff, orchestrator, architect, integrator) should revert.

Before the fix: if the host MANAGER or a MAINTAINER happened to be listed as a team member, deleting the team cleared their standalone title.

### WT-009#2 — Zombie `team` field

After `ChangeTitle(..., 'autonomous', ...)` succeeded, the agent's `team` field in `~/.aimaestro/agents/registry.json` was left untouched. The agent retained `team: "<old-team-name>"` even after the team was gone — confusing every downstream reader that consulted it.

## The fix

In `services/element-management-service.ts`, `DeleteTeam`, Gate G03:

1. **Filter standalone titles.** Before the revert loop, load each agent via `getAgent(aid)` and partition `agentsToRevert` into:
   - `filteredAgentsToRevert` — agents whose `governanceTitle` is NOT in `STANDALONE_TITLES` (the existing constant at line 1386: `{ 'manager', 'autonomous', 'maintainer' }`). These get the `ChangeTitle` call.
   - `skippedStandalone` — MANAGER / MAINTAINER / already-AUTONOMOUS. Logged via `ops.push()` and otherwise untouched.
2. **Still hibernate every agent.** The `for` loop iterates the original `agentsToRevert`, not the filtered list. The `ChangeTitle` call is wrapped in `if (shouldRevertTitle)`, but the hibernate block runs unconditionally — stopping running sessions is the correct behavior on team deletion regardless of title.
3. **Clear the `team` field after successful revert.** Inside `if (titleResult.success)`, call `updateAgent(agentId, { team: '' })`. This mirrors the existing `ChangeTeam` PG01 pattern at line 2953 in the same file. Empty string (not `null`) because `UpdateAgentRequest.team` is typed `team?: string`.

All original comments (BUG-002 SCEN-005 fix, hibernate block) are preserved. Only `services/element-management-service.ts` was touched.

## Verification

- `./node_modules/.bin/tsc --noEmit` → **PASS** (exit 0)
- `yarn build` → **PASS** (exit 0, full Next.js production build, 21.75s)

## Scope

- **Files changed**: 1 (`services/element-management-service.ts`)
- **Lines changed**: +57 / -16
- **Does NOT touch**: `lib/agent-registry.ts`, `types/agent.ts`, any other file. The existing `updateAgent({ team: '' })` pattern at line 2953 is the precedent — no registry or types changes needed.

## Test plan

- [ ] Create a team with a MANAGER as a member → delete the team → verify the MANAGER still holds the MANAGER title.
- [ ] Create a team with a MAINTAINER as a member → delete the team → verify the MAINTAINER still holds the MAINTAINER title (and their `githubRepo` is preserved).
- [ ] Create a team with a MEMBER + COS + ORCHESTRATOR → delete the team → verify they all become AUTONOMOUS and their `team` field in `registry.json` is empty.
- [ ] Re-run SCEN-006, SCEN-007, SCEN-009 end-to-end to confirm the original reports' failures are gone.
