### PR TITLE
fix(sessions): pass AGENT_WORK_DIR + AID_AUTH atomically to tmux new-session (WT-014#1 + WT-022#1)

### DIFF
--- a/lib/agent-runtime.ts
+++ b/lib/agent-runtime.ts
@@ -38,7 +38,16 @@ export interface AgentRuntime {
   cancelCopyMode(name: string): Promise<void>
 
   // Lifecycle
-  createSession(name: string, cwd: string): Promise<void>
+  //
+  // env (optional): key/value pairs passed to `tmux new-session -e KEY=VAL ...`
+  // so they are already set in the session environment BEFORE the first pane's
+  // login shell (and anything it spawns, e.g. `claude`) starts. Using the
+  // `-e` flag is the ONLY way to guarantee these vars are visible to the
+  // already-running process in the initial pane; calling `setEnvironment`
+  // AFTER session creation only affects future panes. Keys must match
+  // `^[A-Z_][A-Z0-9_]*$` (standard env-var naming) — anything else is
+  // rejected as a defense against injection from caller-controlled strings.
+  createSession(name: string, cwd: string, env?: Record<string, string>): Promise<void>
   killSession(name: string): Promise<void>
   renameSession(oldName: string, newName: string): Promise<void>
 
@@ -170,9 +179,32 @@ export class TmuxRuntime implements AgentRuntime {
 
   // -- Lifecycle -----------------------------------------------------------
 
-  async createSession(name: string, cwd: string): Promise<void> {
-    // Use execFileAsync (no shell) to prevent shell injection via name/cwd
-    await execFileAsync('tmux', ['new-session', '-d', '-s', name, '-c', cwd])
+  async createSession(name: string, cwd: string, env?: Record<string, string>): Promise<void> {
+    // Use execFileAsync (no shell) to prevent shell injection via name/cwd.
+    //
+    // WT-014#1 + WT-022#1: env vars MUST be passed via `tmux new-session -e KEY=VAL`
+    // so they are baked into the session environment BEFORE the first pane's
+    // login shell (and anything it launches, e.g. `claude`) starts. Setting the
+    // same vars via `tmux set-environment` AFTER session creation is a race: the
+    // first pane's process tree is already running and inherits nothing from
+    // future set-environment calls. AGENT_WORK_DIR (directory-guard sandbox
+    // boundary) and AID_AUTH (agent HTTP API session secret) must be atomic.
+    const args = ['new-session', '-d', '-s', name, '-c', cwd]
+    if (env) {
+      for (const [key, value] of Object.entries(env)) {
+        // Defense against injection from caller-controlled strings: reject any
+        // key that isn't a strict POSIX environment-variable identifier. This
+        // also blocks accidental CR/LF/`=` that would confuse tmux's KEY=VAL
+        // parsing. Values are NOT sanitized here — execFile (no shell) passes
+        // them as a single argv item to tmux, which in turn stores them as
+        // opaque bytes in the session environment.
+        if (!/^[A-Z_][A-Z0-9_]*$/.test(key)) {
+          throw new Error(`[agent-runtime] Invalid env var name: ${key}`)
+        }
+        args.push('-e', `${key}=${value}`)
+      }
+    }
+    await execFileAsync('tmux', args)
   }
 
   async killSession(name: string): Promise<void> {

--- a/services/sessions-service.ts
+++ b/services/sessions-service.ts
@@ -631,9 +631,24 @@ export async function createSession(params: CreateSessionParams): Promise<Servic
     }
   }
 
-  await runtime.createSession(actualSessionName, cwd)
-
-  // Register agent
+  // ──────────────────────────────────────────────────────────────────────────
+  // PRE-CREATE: build the environment bag for `tmux new-session -e KEY=VAL`.
+  //
+  // Why this happens BEFORE runtime.createSession (WT-014#1 + WT-022#1):
+  //   - AGENT_WORK_DIR is the trusted sandbox boundary read by the directory-
+  //     guard hook. If it is not present the moment `claude` starts, every
+  //     read/write is blocked with "no sandbox configured".
+  //   - AID_AUTH is the session secret the agent uses to authenticate with
+  //     the AI Maestro HTTP API. If it is not present the moment `claude`
+  //     starts, every API call from the agent returns 401.
+  //
+  // `tmux set-environment` (below, kept as a belt-and-braces for future panes)
+  // only updates the session-level env bag — the initial pane's process tree
+  // is already running and inherits nothing from it. The only way to have
+  // the vars present for the already-launching `claude` is to bake them into
+  // `tmux new-session -e KEY=VAL`, which REQUIRES registering the agent and
+  // computing these values BEFORE createSession rather than after.
+  // ──────────────────────────────────────────────────────────────────────────
   const agentName = normalizedName
   let registeredAgent = getAgentByName(agentName)
 
@@ -657,6 +672,71 @@ export async function createSession(params: CreateSessionParams): Promise<Servic
       console.warn(`[Sessions] Could not register agent ${agentName}:`, createError)
     }
   }
+
+  const registeredAgentId = registeredAgent?.id
+
+  // Build the initial env bag for `tmux new-session -e`. Keys without a
+  // resolvable value (e.g. AIM_AGENT_ID when agent registration failed) are
+  // simply omitted — the caller proceeds with a best-effort session rather
+  // than failing. AGENT_WORK_DIR is ALWAYS set because cwd is known by now.
+  const initialEnv: Record<string, string> = {
+    AGENT_WORK_DIR: cwd,
+    AIM_AGENT_NAME: agentName,
+  }
+
+  // AMP init is fast (just mkdir -p) and needs to run before we can compute
+  // AMP_DIR. If it fails, we log and fall back to a session with no AMP_DIR
+  // — AMP is not strictly required for a session to function.
+  let ampDir: string | undefined
+  try {
+    await initAgentAMPHome(agentName, registeredAgentId)
+    ampDir = getAgentAMPDir(agentName, registeredAgentId)
+    initialEnv.AMP_DIR = ampDir
+  } catch (ampErr) {
+    console.warn(`[Sessions] Could not init AMP home for ${agentName}:`, ampErr)
+  }
+
+  if (registeredAgentId) {
+    initialEnv.AIM_AGENT_ID = registeredAgentId
+  }
+
+  // AID_AUTH: server-issued AID session secret for agent API authentication.
+  // The server spawns the agent, so it IS the identity authority for local
+  // agents. The secret must be present before `claude` starts (WT-022#1);
+  // the hash is stored in the registry for validation on incoming requests.
+  // If secret generation or persistence fails, the session proceeds without
+  // AID_AUTH (logged) — this matches the previous fail-open behavior.
+  let aidAuthSet = false
+  if (registeredAgentId) {
+    try {
+      const { generateSessionSecret } = await import('@/lib/session-secret')
+      const { secret, secretHash } = generateSessionSecret()
+      const { updateAgent } = await import('@/lib/agent-registry')
+      await updateAgent(registeredAgentId, {
+        metadata: { sessionSecretHash: secretHash }
+      } as any)
+      initialEnv.AID_AUTH = secret
+      aidAuthSet = true
+      console.log(`[Sessions] Set AID_AUTH for agent ${agentName} (AID session secret)`)
+    } catch (secretErr) {
+      console.warn(`[Sessions] Could not set session secret for ${agentName}:`, secretErr)
+    }
+  }
+
+  // Atomic session creation: env vars are visible to the first pane's
+  // process tree (and therefore to `claude` when it launches below).
+  await runtime.createSession(actualSessionName, cwd, initialEnv)
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // POST-CREATE: session-agent linking, persistence, and belt-and-braces env.
+  //
+  // The setEnvironment calls here duplicate what we just did atomically via
+  // `-e`, but they are intentional: they update the session-level environment
+  // bag that tmux hands to *future* panes (e.g. if the user opens a second
+  // pane in the same session via tmux binding). Without these, opening a new
+  // pane would lose AMP_DIR/AGENT_WORK_DIR/AID_AUTH. Keeping them is cheap
+  // (one `tmux set-environment` per key) and protects the future-pane path.
+  // ──────────────────────────────────────────────────────────────────────────
 
   // Record session-agent pairing in persistent history (survives agent deletion)
   if (registeredAgent) {
@@ -692,49 +772,26 @@ export async function createSession(params: CreateSessionParams): Promise<Servic
     ...(registeredAgent && { agentId: registeredAgent.id })
   })
 
-  // Initialize AMP
-  const registeredAgentId = registeredAgent?.id
+  // Belt-and-braces: refresh session-level env for any future pane opened in
+  // this session. These duplicate the `-e` values above and are best-effort.
   try {
-    await initAgentAMPHome(agentName, registeredAgentId)
-    const ampDir = getAgentAMPDir(agentName, registeredAgentId)
-    await runtime.setEnvironment(actualSessionName, 'AMP_DIR', ampDir)
+    if (ampDir) {
+      await runtime.setEnvironment(actualSessionName, 'AMP_DIR', ampDir)
+    }
     await runtime.setEnvironment(actualSessionName, 'AIM_AGENT_NAME', agentName)
     if (registeredAgentId) {
       await runtime.setEnvironment(actualSessionName, 'AIM_AGENT_ID', registeredAgentId)
     }
-    // AGENT_WORK_DIR is the trusted sandbox boundary for the directory guard hook.
-    // Set at session creation, immutable — the agent cannot change it via `cd`.
     await runtime.setEnvironment(actualSessionName, 'AGENT_WORK_DIR', cwd)
-
-    // AID_AUTH: server-issued AID session secret for agent API authentication.
-    // The server spawns the agent, so it IS the identity authority for local agents.
-    // The secret is set as a tmux env var (scoped to this session's process tree).
-    // No Ed25519 ceremony needed — the server trusts itself.
-    if (registeredAgentId) {
-      try {
-        const { generateSessionSecret } = await import('@/lib/session-secret')
-        const { secret, secretHash } = generateSessionSecret()
-        await runtime.setEnvironment(actualSessionName, 'AID_AUTH', secret)
-        // Store the hash in agent registry for validation
-        const { updateAgent } = await import('@/lib/agent-registry')
-        await updateAgent(registeredAgentId, {
-          metadata: { sessionSecretHash: secretHash }
-        } as any)
-        console.log(`[Sessions] Set AID_AUTH for agent ${agentName} (AID session secret)`)
-      } catch (secretErr) {
-        console.warn(`[Sessions] Could not set session secret for ${agentName}:`, secretErr)
-      }
+    if (aidAuthSet && initialEnv.AID_AUTH) {
+      await runtime.setEnvironment(actualSessionName, 'AID_AUTH', initialEnv.AID_AUTH)
     }
-
     await runtime.unsetEnvironment(actualSessionName, 'CLAUDECODE')
-    // Removed redundant sendKeys export command -- tmux set-environment (above)
-    // already sets AMP_DIR, AIM_AGENT_NAME, and AIM_AGENT_ID in the session environment.
-    // The previous sendKeys approach interpolated unsanitized values into a shell command string,
-    // creating a shell injection vector. tmux set-environment is safe because it does not
-    // invoke a shell.
-    console.log(`[Sessions] Set AMP_DIR=${ampDir} for agent ${agentName}`)
+    if (ampDir) {
+      console.log(`[Sessions] Set AMP_DIR=${ampDir} for agent ${agentName}`)
+    }
   } catch (ampError) {
-    console.warn(`[Sessions] Could not set up AMP for ${agentName}:`, ampError)
+    console.warn(`[Sessions] Could not refresh session env for ${agentName}:`, ampError)
   }
 
   // Launch program


### PR DESCRIPTION
## Summary

Fixes **P0 WT-014#1 + WT-022#1** (SCEN-014 / SCEN-022 reports): `services/sessions-service.ts::createSession()` was passing `AGENT_WORK_DIR`, `AMP_DIR`, `AIM_AGENT_NAME`, `AIM_AGENT_ID`, and `AID_AUTH` to tmux via `tmux set-environment` AFTER the session's initial pane was already running. The Claude Code process therefore inherited an empty environment, making:

- the **directory-guard hook** block every read/write with "no sandbox configured" because `AGENT_WORK_DIR` was unset (SCEN-014)
- every **agent API call** return 401 because `AID_AUTH` was never visible to the agent (SCEN-022)

Both are two faces of the same race. This PR bakes the env vars into `tmux new-session -e KEY=VAL ...` so the session is born with them already set.

## Changes

### `lib/agent-runtime.ts`

- Extended `AgentRuntime.createSession` with an **optional** `env?: Record<string, string>` third parameter (doc block explains the race and why atomic pass via `-e` is the only correct path).
- `TmuxRuntime.createSession` now validates each env key against `^[A-Z_][A-Z0-9_]*$` (strict POSIX identifier — blocks CR/LF/`=` in keys and injection from caller-controlled strings), then appends `-e KEY=VAL` pairs to the argv list before `execFileAsync('tmux', args)`. Values are NOT sanitized because `execFile` (no shell) passes them as opaque argv items to tmux.

### `services/sessions-service.ts`

Reordered the existing logic inside `createSession` without changing behavior for any code path except the race condition:

- **Before:** `runtime.createSession(name, cwd)` → then `createAgent` → `initAgentAMPHome` → `generateSessionSecret` → chain of `runtime.setEnvironment(...)` calls on the already-running session.
- **After:**
  1. **PRE-CREATE:** run `createAgent`, `initAgentAMPHome`, `generateSessionSecret` + `updateAgent({sessionSecretHash})` FIRST, and build an `initialEnv` bag.
  2. **CREATE:** `runtime.createSession(name, cwd, initialEnv)` — atomic with the session's birth.
  3. **POST-CREATE:** `recordSessionPairing`, `persistSession`, **and** a belt-and-braces loop of `runtime.setEnvironment` calls that mirror `initialEnv` back to the session-level env bag. This ensures any future pane opened inside the session (e.g. via a tmux keybinding) also inherits the vars.

All error semantics are preserved: AMP init failure, secret generation failure, and agent registration failure all log a warning and proceed (fail-open), exactly as before — just the failing keys are omitted from the env bag.

## Out of scope

The wake path in `services/agents-core-service.ts::wakeAgent` (line 1645) has the **same** race but uses a different anti-pattern (env vars exported via `runtime.sendKeys` shell command). Fixing that is a separate PR because:

1. The task prompt explicitly scopes this fix to `services/sessions-service.ts`.
2. Migrating wake to the `-e` approach also touches the R17 plugin install, the "terminal only" branch, and the CC-P1-514 shell-escape logic — a larger refactor.
3. Landing two orthogonal fixes in one PR would make review harder.

Recommended follow-up: `p0-wake-env-atomic`.

## Other `runtime.createSession` callers

The new `env` parameter is **optional**, so the other four callers are unchanged and still compile:

| File | Line | Affected? |
|------|------|-----------|
| `services/sessions-service.ts` | 962 (restore-on-startup) | No — session just needs an empty pane |
| `services/help-service.ts` | 131 | No — help assistant runs in the AI Maestro source tree |
| `services/creation-helper-service.ts` | 494 | No — same as help-service |
| `services/agents-core-service.ts` | 1645 (wakeAgent) | Has the same bug — see "Out of scope" |

## Verification

```
$ npx tsc --noEmit
EXIT=0

$ yarn build
…
Done in 26.08s.
EXIT=0
```

## Test plan

- [ ] Re-run SCEN-014 (directory-guard hook) — `AGENT_WORK_DIR` is visible in `env` when Claude Code starts, hook no longer blocks reads/writes inside the sandbox.
- [ ] Re-run SCEN-022 (AID auth) — `AID_AUTH` is visible in `env` when Claude Code starts, agent API calls authenticate.
- [ ] Verify on a fresh session: `tmux show-environment -t <session> | grep -E '(AGENT_WORK_DIR|AMP_DIR|AID_AUTH|AIM_AGENT_)'` shows all 5 keys.
- [ ] Verify from inside Claude: agent can read `$AGENT_WORK_DIR`, `$AID_AUTH`, `$AMP_DIR` from its own environment.
- [ ] Smoke-test the non-affected callers (help agent wake, Haephestos creation helper, session restore) to confirm they still work.

## Implementer report

`docs_dev/2026-04-15-wt-014-022-session-env-implementer-report.md` has full details including the error-semantics analysis and line-by-line changes.
