### PR TITLE
fix(install-element): dispatch install/uninstall through client-plugin-adapter (WT-013#1)

### DIFF
--- a/services/element-management-service.ts
+++ b/services/element-management-service.ts
@@ -498,9 +498,73 @@ export async function InstallElement(
       await mkdir(join(cwd, '.claude'), { recursive: true })
     }
 
+    // WT-013#1: Dispatch install/uninstall through the client-plugin-adapter
+    // system when the agent's client is not Claude. Previously this block
+    // unconditionally invoked `claude plugin install`, which wrote to the
+    // Claude cache even for Codex/Gemini/OpenCode/Kiro agents (or no-oped
+    // entirely if the claude CLI wasn't installed). The adapter system
+    // (lib/client-plugin-adapters/) knows the per-client plugin layout and
+    // install mechanism, so we route non-Claude installs through it.
+    //
+    // Claude remains on the existing CLI+settings.local.json fallback path
+    // to preserve exact behavior for the default client. If clientType is
+    // unrecognized ('unknown' or anything else), defense-in-depth falls
+    // back to the Claude path with a warning (NOT abort — that would break
+    // existing agents whose program field might be empty or mis-detected).
+    const useAdapter = clientType !== 'claude' && clientType !== 'unknown'
+    let adapter: import('@/lib/client-plugin-adapters/types').ClientPluginAdapter | null = null
+    if (useAdapter) {
+      try {
+        const { getAdapter } = await import('@/lib/client-plugin-adapters')
+        adapter = await getAdapter(clientType as import('@/lib/client-capabilities').ClientType)
+        if (!adapter) {
+          ops.push(`EXE: WARN — no adapter registered for client "${clientType}", defaulting to claude path`)
+        } else {
+          ops.push(`EXE: Using ${clientType} adapter for ${action}`)
+        }
+      } catch (adapterErr) {
+        ops.push(`EXE: WARN — failed to load adapter for "${clientType}": ${adapterErr instanceof Error ? adapterErr.message : adapterErr}. Falling back to claude path.`)
+        adapter = null
+      }
+    } else if (clientType !== 'claude') {
+      ops.push(`EXE: WARN — unknown client "${clientType}", defaulting to claude`)
+    }
+
     try {
       switch (action) {
         case 'install': {
+          // ── Adapter dispatch (non-Claude clients) ──
+          if (adapter && (clientType === 'codex' || clientType === 'gemini' || clientType === 'opencode' || clientType === 'kiro')) {
+            // Build a StoredPlugin from the G13 conversion output. If G13
+            // failed to produce a directory, abort — we cannot ask the
+            // adapter to install a plugin that wasn't emitted for the
+            // target client.
+            if (!convertedDir) {
+              result.error = `EXE: No converted plugin directory for ${clientType} — G13 conversion did not emit output. Cannot install "${name}" via ${clientType} adapter.`
+              ops.push(result.error)
+              return result
+            }
+            const { clientTypeToProviderId } = await import('@/lib/client-capabilities')
+            const providerId = clientTypeToProviderId(clientType as import('@/lib/client-capabilities').ClientType) as import('@/lib/converter/types').ProviderId
+            const storedPlugin: import('@/lib/client-plugin-adapters/types').StoredPlugin = {
+              name,
+              clientType: clientType as import('@/lib/client-capabilities').ClientType,
+              storageDir: convertedDir,
+              providerId,
+              sourcePlugin: name,
+              sourceClient: 'claude',
+            }
+            const adapterResult = await adapter.install(storedPlugin, cwd, { scope, marketplace: resolvedMarketplace })
+            if (!adapterResult.success) {
+              result.error = `EXE: ${clientType} adapter install failed: ${adapterResult.error || 'unknown error'}`
+              ops.push(result.error)
+              return result
+            }
+            ops.push(`EXE: Installed via ${clientType} adapter — ${name} → ${convertedDir}`)
+            break
+          }
+
+          // ── Claude path (default + fallback for unknown clients) ──
           let cliSuccess = false
           try {
             const cliResult = await execFileAsync('claude', [
@@ -531,6 +595,34 @@ export async function InstallElement(
         }
 
         case 'uninstall': {
+          // ── Adapter dispatch (non-Claude clients) ──
+          if (adapter && (clientType === 'codex' || clientType === 'gemini' || clientType === 'opencode' || clientType === 'kiro')) {
+            // For uninstall we construct a minimal StoredPlugin. The adapter
+            // locates the plugin via its tracking manifest or by name — the
+            // storageDir is only needed for install, not uninstall.
+            const { clientTypeToProviderId } = await import('@/lib/client-capabilities')
+            const providerId = clientTypeToProviderId(clientType as import('@/lib/client-capabilities').ClientType) as import('@/lib/converter/types').ProviderId
+            const storedPlugin: import('@/lib/client-plugin-adapters/types').StoredPlugin = {
+              name,
+              clientType: clientType as import('@/lib/client-capabilities').ClientType,
+              storageDir: convertedDir || '',
+              providerId,
+              sourcePlugin: name,
+              sourceClient: 'claude',
+            }
+            const adapterResult = await adapter.uninstall(storedPlugin, cwd, { scope })
+            if (!adapterResult.success) {
+              // Uninstall is best-effort — log but don't abort. The settings
+              // fallback below will still try to clean up any settings-level
+              // references, which matters for Claude-compatible paths.
+              ops.push(`EXE: WARN — ${clientType} adapter uninstall failed: ${adapterResult.error || 'unknown'}`)
+            } else {
+              ops.push(`EXE: Uninstalled via ${clientType} adapter — ${name}`)
+            }
+            break
+          }
+
+          // ── Claude path (default + fallback for unknown clients) ──
           try {
             const cliResult = await execFileAsync('claude', [
               'plugin', 'uninstall', `${name}@${resolvedMarketplace}`, '--scope', scope,


### PR DESCRIPTION
## Summary

P0 fix for **SCEN-013 WT-013#1**: `InstallElement` hardcoded `claude plugin install/uninstall` regardless of the agent's `program` field, so Codex (and other non-Claude) agents had plugins written to the Claude cache or silently no-op'd.

This PR routes install/uninstall through the existing `lib/client-plugin-adapters/` system for non-Claude clients. Claude agents keep the exact same code path (CLI + settings.local.json fallback) — zero behavior change for the default case.

**Status: DRAFT** — orchestrator should review the adapter dispatch policy before merge.

## What changed

Only one function in one file is touched: `InstallElement` in `services/element-management-service.ts` (92 lines added, 0 removed).

Inside the `EXE` block:
- **Pre-resolve** a `ClientPluginAdapter` via `getAdapter(clientType)` when the client is not Claude
- **`install` case**: if the adapter resolved AND client is codex/gemini/opencode/kiro, build a `StoredPlugin` from the `G13`-produced `convertedDir` and call `adapter.install(...)`. Previously `convertedDir` was computed but never consumed.
- **`uninstall` case**: same adapter dispatch. Uninstall is best-effort so adapter failure logs WARN instead of aborting.
- **Fallthrough**: unknown/unrecognized clients fall through to the Claude path with a WARN in `ops` (defense-in-depth — never abort for agents with missing `program` field).

## What was NOT changed

- Any other function in `element-management-service.ts`
- `lib/client-plugin-adapters/` (read-only audit only)
- Pre-gates `G00`..`G13` and post-gates `PG01`..`PG08` — strictly additive inside EXE
- `enable`, `disable`, and `update` cases (out of scope — codex adapter no-ops enable/disable anyway)
- The `G13` conversion block — left intact; the new EXE block is the first consumer of `convertedDir`

## Critical invariants preserved

1. **Claude client unchanged** — same CLI + settings.local.json fallback path
2. **Unknown client fallback** — never abort, WARN and fall through to Claude path
3. **G13 contract** — if non-Claude dispatch fires, `convertedDir` is required; missing it aborts with a diagnostic instead of silently no-op'ing
4. **Role-plugin guard (G09)** — still enforced
5. **Core plugin guard (G08)** — still enforced
6. **All post-gates PG01..PG08** — still run after adapter dispatch

## Verification

- `npx tsc --noEmit` → exit 0 (PASS)
- `yarn build` → "Compiled with warnings" (TypeScript phase PASS). Build subsequently fails in "Collecting page data" due to `cozo-node` missing prebuilt native binary — **pre-existing env issue, present on the base commit with changes stashed, NOT caused by this PR**.
- `yarn lint` → pre-existing `@next/next` plugin config conflict from a parent-directory `.eslintrc.json` (outside this repo). Also present on base commit.

## Follow-up work (NOT in this PR)

1. **Route `update` through adapters** — same class of bug, lower priority
2. **Relax `G07`'s `instCaps.plugins` check** once element-adapter fully supports install/uninstall for gemini/opencode/kiro — the dispatch in this PR is ready
3. **Route `enable`/`disable`** via the adapter — needs element-adapter enable/disable support first

Tracked as P1/P2 in the SCEN-013 report.

## Test plan

- [ ] Create a Codex agent
- [ ] Install a non-role plugin from the marketplace via `InstallElement`
- [ ] Verify the plugin files land in `<agentDir>/.codex-plugin/...` and NOT in `~/.codex/plugins/cache/` or `<agentDir>/.claude/...`
- [ ] Uninstall the plugin via `InstallElement`
- [ ] Verify `<agentDir>/.codex-plugin/...` is cleaned up
- [ ] Repeat for a Claude agent and confirm no behavior change
- [ ] Run SCEN-013 from `tests/scenarios/` end-to-end once the env issues (cozo-node native binary) are resolved
