### PR TITLE
fix(haephestos): extend watchdog to 30min + client visibilitychange/retry (WT-004#1)

### DIFF
--- a/components/HaephestosEmbeddedView.tsx
+++ b/components/HaephestosEmbeddedView.tsx
@@ -104,14 +104,90 @@ export default function HaephestosEmbeddedView({ agent, onAgentCreated }: Haephe
     finally { setWaking(false) }
   }, [])
 
-  // Heartbeat: keep the server-side watchdog alive (only when online)
+  // Heartbeat: keep the server-side watchdog alive (only when online).
+  //
+  // WT-004#1: three improvements over the naive setInterval+fetch version:
+  //   1. visibilitychange suspend — when the tab is hidden, stop sending
+  //      heartbeats (saves battery and connections). Resume + send
+  //      immediately when the tab becomes visible again. Safe because the
+  //      server-side watchdog is now 30min (far longer than any typical
+  //      tab-switch break).
+  //   2. retry with exponential backoff — a single 1s network hiccup must
+  //      NOT cause a missed heartbeat (which could escalate toward a false
+  //      kill). Retry up to 3 times with backoff 1s/2s/4s. Only if all 3
+  //      fail do we log an error and move on; the next interval tick will
+  //      try again.
+  //   3. cleanup: interval AND visibilitychange listener both torn down
+  //      on unmount (or when the agent goes offline).
   useEffect(() => {
     if (!isOnline) return
-    const heartbeatInterval = setInterval(() => {
-      fetch('/api/agents/creation-helper/heartbeat', { method: 'POST' }).catch(() => {})
-    }, 30_000)
-    fetch('/api/agents/creation-helper/heartbeat', { method: 'POST' }).catch(() => {})
-    return () => clearInterval(heartbeatInterval)
+
+    let cancelled = false
+    let heartbeatInterval: ReturnType<typeof setInterval> | null = null
+
+    const sendHeartbeatWithRetry = async () => {
+      // Three-attempt retry with exponential backoff: 1s, 2s, 4s.
+      // This is retry-BETWEEN-attempts, not retry-AFTER-failure — the next
+      // 30s interval tick will make a fresh attempt regardless.
+      const backoffs = [1000, 2000, 4000]
+      for (let attempt = 0; attempt < 3; attempt++) {
+        if (cancelled) return
+        try {
+          const res = await fetch('/api/agents/creation-helper/heartbeat', { method: 'POST' })
+          if (res.ok) return
+        } catch { /* network error, fall through to retry */ }
+        // Don't sleep after the final attempt — just give up and let the
+        // next interval tick handle it.
+        if (attempt < 2) {
+          await new Promise(resolve => setTimeout(resolve, backoffs[attempt]))
+        }
+      }
+      // All 3 attempts failed — log once so this is visible in devtools but
+      // don't crash the UI. The next interval tick may succeed.
+      console.warn('[Haephestos] Heartbeat failed after 3 attempts (1s/2s/4s backoff); will retry on next interval')
+    }
+
+    const startInterval = () => {
+      if (heartbeatInterval) return
+      heartbeatInterval = setInterval(() => { void sendHeartbeatWithRetry() }, 30_000)
+    }
+
+    const stopInterval = () => {
+      if (heartbeatInterval) {
+        clearInterval(heartbeatInterval)
+        heartbeatInterval = null
+      }
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        // Tab is hidden: pause the interval. Server watchdog is 30min so
+        // we have plenty of headroom before a missing heartbeat matters.
+        stopInterval()
+      } else {
+        // Tab is visible again: send one immediately + resume the interval.
+        void sendHeartbeatWithRetry()
+        startInterval()
+      }
+    }
+
+    // Initial heartbeat + start the interval. If the tab starts hidden
+    // (unusual for this flow but possible via background-tab open),
+    // visibilitychange will pause it below.
+    void sendHeartbeatWithRetry()
+    startInterval()
+
+    if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+      stopInterval()
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    return () => {
+      cancelled = true
+      stopInterval()
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
   }, [isOnline])
 
   // Sync raw materials state to disk so Haephestos can read it

--- a/services/creation-helper-service.ts
+++ b/services/creation-helper-service.ts
@@ -76,7 +76,17 @@ let creationHelperPromise: Promise<ServiceResult<{
 // If no heartbeat is received for WATCHDOG_TIMEOUT_MS, the session is killed.
 // This prevents zombie sessions from running indefinitely if the browser
 // tab closes without triggering beforeunload cleanup.
-const WATCHDOG_TIMEOUT_MS = 2 * 60 * 1000 // 2 minutes
+//
+// WT-004#1: Timeout increased from 2min to 30min. Interactive role-plugin
+// creation can involve long user pauses — reading Claude's suggestions,
+// filling multi-step forms, reviewing TOML preview, approving plans — any
+// of which can legitimately exceed 2min without heartbeats (e.g. a tab in
+// the background, a user stepping away to check something). 30min matches
+// the typical Claude Code idle timeout and balances resource cleanup with
+// user tolerance. Five zombie-safeguard layers still protect us from true
+// leaks: beforeunload+sendBeacon, visibilitychange (client-side suspend),
+// this server watchdog, startup cleanup, and tightened tmux permissions.
+const WATCHDOG_TIMEOUT_MS = 30 * 60 * 1000 // 30 minutes
 let lastHeartbeat: number = 0
 let watchdogTimer: ReturnType<typeof setInterval> | null = null
 


### PR DESCRIPTION
## Summary

P0 fix for WT-004#1 from SCEN-004. The Haephestos embedded session watchdog
killed sessions after 2 minutes of no heartbeat — far too short for
interactive role-plugin creation, which often involves multi-minute user
pauses for reading, form filling, and TOML review.

This PR ships three coordinated changes that eliminate false kills:

- **Server watchdog timeout: 2min → 30min**
  `services/creation-helper-service.ts`. Matches the typical Claude Code
  idle timeout. The five existing zombie-safeguard layers (beforeunload +
  sendBeacon, visibilitychange on the page, startup cleanup, tightened
  tmux permissions, this watchdog) still protect against true leaks.

- **Client heartbeat: visibilitychange suspend**
  `components/HaephestosEmbeddedView.tsx`. When the tab becomes hidden
  the heartbeat interval is paused (saving battery and connections).
  When visible again, a fresh heartbeat is sent immediately and the
  interval resumes.

- **Client heartbeat: retry with exponential backoff**
  Each heartbeat fetch now retries up to 3 times with 1s / 2s / 4s
  backoff before logging a `console.warn` and falling through. A single
  transient network hiccup no longer skips a heartbeat.

Heartbeat interval unchanged at 30s. With the new 30-min server watchdog
there's no reason to bump it.

## Files changed

- `services/creation-helper-service.ts` (+11 / -1)
- `components/HaephestosEmbeddedView.tsx` (+82 / -6)

No other files touched. No removal of existing zombie-safeguard layers.
No API signature changes.

## Test plan

- [x] `npx tsc --noEmit` — exit 0, zero output (verified during implementation)
- [x] `yarn build` — fails only on pre-existing `cozo-node` native binary issue
      (unrelated, not caused by these changes). Changed files do not import
      `cozo-node`, confirmed by reading them top-to-bottom.
- [ ] Manual: wake Haephestos, fill form, hide the tab for 3min, return,
      verify session is still alive.
- [ ] Manual: wake Haephestos, disconnect WiFi for 2-3s, reconnect, verify
      heartbeat retries succeeded and session is still alive.
- [ ] Manual: wake Haephestos, close tab, verify session is eventually
      killed by beforeunload+sendBeacon OR the 30-min watchdog (whichever
      fires first — typically beforeunload).

## Refs

- SCEN-004 scenario report (P0 WT-004#1)
- Full implementation report: `docs_dev/2026-04-15-wt-004-1-haephestos-watchdog-report.md`
