### PR TITLE
fix(marketplaces-tab): stamp marketplaceName on role-plugin install (WT-021#1)

### DIFF
--- a/components/agent-profile/MarketplacesTab.tsx
+++ b/components/agent-profile/MarketplacesTab.tsx
@@ -52,14 +52,19 @@ export default function MarketplacesTab({ workingDirectory, installedPluginNames
 
   useEffect(() => { fetchMarketplaces() }, [fetchMarketplaces])
 
-  const handleInstall = async (pluginName: string) => {
+  // WT-021#1: the caller MUST pass the marketplace name of the plugin being
+  // installed, not just the plugin name. Without it the install API falls
+  // back to `ai-maestro-local-roles-marketplace` regardless of which
+  // marketplace the UI displayed, which silently installs the wrong plugin
+  // when a non-default marketplace has a plugin with the same name.
+  const handleInstall = async (pluginName: string, marketplaceName: string) => {
     if (!workingDirectory || installing) return
     setInstalling(pluginName)
     try {
       const res = await fetch('/api/agents/role-plugins/install', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ pluginName, agentDir: workingDirectory, scope: 'local' }),
+        body: JSON.stringify({ pluginName, marketplaceName, agentDir: workingDirectory, scope: 'local' }),
       })
       if (!res.ok) {
         const err = await res.json().catch(() => ({ error: 'Install failed' }))
@@ -175,7 +180,7 @@ export default function MarketplacesTab({ workingDirectory, installedPluginNames
                                 </span>
                               ) : (
                                 <button
-                                  onClick={() => handleInstall(p.name)}
+                                  onClick={() => handleInstall(p.name, mkt.name)}
                                   disabled={!workingDirectory || installing === p.name}
                                   className="flex items-center gap-1 text-[9px] text-blue-400 hover:text-blue-300 px-1.5 py-0.5 rounded disabled:opacity-50"
                                   title="Install to this agent (--scope local)"


### PR DESCRIPTION
## Summary

Single-line UI fix. The MarketplacesTab "Install" button POSTs to `/api/agents/role-plugins/install` without a `marketplaceName` field, so the API silently falls back to the default marketplace when a user installs from a non-default one — breaking correctness for any plugin collision across marketplaces.

## Root cause (WT-021#1 from SCEN-021)

`components/agent-profile/MarketplacesTab.tsx:55-75`:

```ts
const handleInstall = async (pluginName: string) => {
  // ...
  body: JSON.stringify({ pluginName, agentDir: workingDirectory, scope: 'local' }),
  // ← no marketplaceName
```

And the button:
```tsx
onClick={() => handleInstall(p.name)}  // ← marketplace name not passed
```

The API at `app/api/agents/role-plugins/install/route.ts:47` correctly accepts `body.marketplaceName` and falls back to the predefined marketplace or the local roles marketplace. Since the UI never sends it, every install gets stamped with the wrong marketplace on non-default marketplaces. The plugin still installs (because Claude CLI resolves by plugin name), but `settings.local.json` records the wrong `marketplace` key, breaking `settings.local.json`-based compat checks and the `installedPluginNames` set.

## Fix

1. Extend `handleInstall` to accept `marketplaceName` as a second positional arg.
2. Add `marketplaceName` to the POST body.
3. Update the button `onClick` to pass `mkt.name` alongside `p.name`.

Belt-and-braces: the API fallback still works, so this PR strictly narrows the bug without breaking existing behavior.

## Verification

- `npx tsc --noEmit`: **PASS** (exit 0)

## Diff stat

```
 components/agent-profile/MarketplacesTab.tsx | 11 ++++++++---
 1 file changed, 8 insertions(+), 3 deletions(-)
```

## Test plan
- [ ] Review the 1-file change
- [ ] Sanity check: install a plugin from a non-default marketplace, then read `settings.local.json` — verify the `marketplace` key matches the source, not the fallback