### PR TITLE
fix(title-dialog): compare against registry, not computed display title (WT-010#2)

### DIFF
--- a/components/AgentProfile.tsx
+++ b/components/AgentProfile.tsx
@@ -1575,6 +1575,15 @@ export default function AgentProfile({ isOpen, onClose, agentId, sessionStatus, 
           agentId={agent.id}
           agentName={agent.label || agent.name || ''}
           currentTitle={governance.agentTitle}
+          // WT-010#2 (2026-04-15): Pass the RAW registry `governanceTitle` so the
+          // dialog's "no change" guard compares against the authoritative stored
+          // value rather than `useGovernance.agentTitle`, which is a derived
+          // display title that can silently diverge from the registry (e.g.
+          // registry says `member` but the agent is no longer in any team, so
+          // the derivation returns `autonomous`). Without this, clicking a
+          // title that matched the stale derived value would be mistaken for
+          // "no change" and the API call would never fire.
+          registryTitle={agent.governanceTitle ?? null}
           governance={governance}
           onTitleChanged={() => { governance.refresh(); onDataChangedRef.current?.() }}
           onRestartNeeded={() => {

--- a/components/governance/TitleAssignmentDialog.impl.tsx
+++ b/components/governance/TitleAssignmentDialog.impl.tsx
@@ -43,6 +43,28 @@ interface TitleAssignmentDialogProps {
   agentId: string
   agentName: string
   currentTitle: GovernanceTitle
+  /**
+   * Raw registry `governanceTitle` value fetched directly from `GET /api/agents/{id}`.
+   *
+   * WT-010#2 (2026-04-15): `currentTitle` comes from `useGovernance.agentTitle`,
+   * which is a useMemo-derived *display* value that may diverge from the raw
+   * registry field (e.g. the registry says `member` but the agent is no longer
+   * in any team, so the derivation falls back to `autonomous`). When that
+   * happens, the "no change" check in `isConfirmDisabled` used to compare
+   * against the derived value and silently block legitimate title assignments
+   * that would have fixed the stale registry state.
+   *
+   * The fix: use `registryTitle` for the "no change" comparison. `currentTitle`
+   * is still used for the initial radio selection and for the branching inside
+   * `handleRoleChange` (which is about transition flow, not equality), so the
+   * UI visually matches the derived display while the enable/disable gate
+   * reflects the authoritative registry value.
+   *
+   * Optional for backward compatibility with any caller that has not yet
+   * been updated; when omitted the old behaviour (compare against
+   * `currentTitle`) is preserved.
+   */
+  registryTitle?: GovernanceTitle | null
   governance: GovernanceState
   onTitleChanged: () => void
   onRestartNeeded?: () => void
@@ -140,6 +162,7 @@ export default function TitleAssignmentDialog({
   agentId,
   agentName,
   currentTitle,
+  registryTitle,
   governance,
   onTitleChanged,
   onRestartNeeded,
@@ -273,10 +296,22 @@ export default function TitleAssignmentDialog({
   // an error the instant the MAINTAINER option is clicked but before any input.
   const githubRepoError = githubRepo.trim().length > 0 ? validateGithubRepo(githubRepo) : null
 
+  // WT-010#2 (2026-04-15): Compare against the RAW registry `governanceTitle`
+  // (not `currentTitle`) for the "no change" check. `currentTitle` comes from
+  // `useGovernance.agentTitle`, which is a derived display value that can
+  // silently diverge from the authoritative registry field (e.g. registry
+  // says `member` but no team membership → derivation returns `autonomous`).
+  // When that happens, comparing against the derived value would silently
+  // block legitimate title changes that would have re-aligned the registry
+  // with reality. Falls back to `currentTitle` when `registryTitle` is not
+  // provided, so the old behaviour is preserved for any caller that has not
+  // been updated yet.
+  const comparisonTitle: GovernanceTitle = registryTitle ?? currentTitle
+
   // Determine if confirm button should be disabled
   const isConfirmDisabled = (() => {
     // No change from current role and no team selection difference
-    if (selectedTitle === currentTitle) {
+    if (selectedTitle === comparisonTitle) {
       if (selectedTitle !== 'chief-of-staff') return true
       // For COS, check if team selection changed
       const currentCosTeamIds = governance.cosTeams.map((t) => t.id).sort()


### PR DESCRIPTION
## Summary

Fixes a silent bug in TitleAssignmentDialog where the 'no change' check disabled Confirm on legitimate title assignments that would have fixed stale registry state.

## Root cause (WT-010#2 from SCEN-010)

The dialog compared `selectedTitle` against `currentTitle`, which flows from `useGovernance.agentTitle` (a useMemo derivation merging managerId, team.chiefOfStaffId, team.orchestratorId, and — as a fallback — the stored `governanceTitle`).

When the derivation diverges from the raw registry (e.g. registry says `member` but the agent is no longer in any team → derivation falls through to `autonomous`), the dialog would silently block the user from confirming a re-alignment to `member`. The registry stayed stale.

## Fix

Add an optional `registryTitle?: GovernanceTitle | null` prop. The 'no change' check at `isConfirmDisabled` compares against `registryTitle ?? currentTitle` so old callers are unaffected. `AgentProfile.tsx` now passes `registryTitle={agent?.governanceTitle ?? null}` alongside the existing `currentTitle={governance.agentTitle}`.

## Verification

- `npx tsc --noEmit`: PASS

## Diff stat

```
 components/AgentProfile.tsx                              |  9 ++++++
 components/governance/TitleAssignmentDialog.impl.tsx     | 37 +++++++++++++++++++++-
 2 files changed, 45 insertions(+), 1 deletion(-)
```

## Test plan
- [ ] Review the prop threading
- [ ] Sanity check: create a state where registry.governanceTitle differs from useGovernance.agentTitle, then verify the dialog enables Confirm correctly