### PR TITLE
feat(team-card): R12 composition warning badge (WT-010#3)

### DIFF
--- a/components/sidebar/TeamCard.tsx
+++ b/components/sidebar/TeamCard.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useState } from 'react'
-import { Pencil, Trash2 } from 'lucide-react'
+import { useState, useMemo } from 'react'
+import { Pencil, Trash2, AlertTriangle } from 'lucide-react'
 import type { Team } from '@/types/team'
 import type { Agent } from '@/types/agent'
+import { checkTeamComposition } from '@/lib/team-composition'
 
 interface TeamCardProps {
   team: Team
@@ -27,6 +28,12 @@ export default function TeamCard({ team, agents, onStartMeeting: _onStartMeeting
   const shown = memberAgents.slice(0, maxAvatars)
   const overflow = memberAgents.length - maxAvatars
 
+  // WT-010#3 (SCEN-010 P0): R12 composition check — flag teams that
+  // are missing required titles so the user can spot incomplete teams
+  // at a glance without opening each one. Pure-function derivation;
+  // memoized against `agents` identity so renders are cheap.
+  const composition = useMemo(() => checkTeamComposition(team, agents), [team, agents])
+
   const getInitials = (agent: Agent | undefined) => {
     if (!agent) return '?'
     const name = agent.label || agent.name || '?'
@@ -40,6 +47,18 @@ export default function TeamCard({ team, agents, onStartMeeting: _onStartMeeting
           <div className="flex items-center gap-2">
             <span className="text-sm font-medium text-gray-200 truncate">{team.name}</span>
             <span className="text-xs text-gray-500 flex-shrink-0">{team.agentIds.length}</span>
+            {/* WT-010#3: R12 composition warning badge. Yellow/amber
+                (not red) because a non-functional team is still
+                recoverable — it needs attention, not alarm. */}
+            {!composition.complete && (
+              <span
+                className="flex items-center gap-0.5 text-[9px] px-1.5 py-0.5 rounded-full bg-amber-500/15 text-amber-400 flex-shrink-0"
+                title={`R12: missing ${composition.missing.join(', ')}`}
+              >
+                <AlertTriangle className="w-2.5 h-2.5" />
+                R12
+              </span>
+            )}
           </div>
 
           {team.description && (

--- a/lib/team-composition.ts
+++ b/lib/team-composition.ts
@@ -1,0 +1,53 @@
+/**
+ * Team composition check (R12)
+ *
+ * WT-010#3 (SCEN-010 P0): R12 is already enforced server-side in
+ * `services/element-management-service.ts` (PG06 gate), but it was never
+ * surfaced in the UI. This function is the client-side mirror of the
+ * PG06 check — given a team and the full agent list, it returns whether
+ * the team meets the R12 minimum-composition requirement (all 5 required
+ * titles present) and, if not, which titles are missing.
+ *
+ * The server is still the authority — this is purely a UI hint so users
+ * can see at a glance which teams need attention. If the client's view
+ * lags behind the server for a moment (registry write vs. UI refetch),
+ * a stale badge is an acceptable tradeoff for the feedback.
+ */
+
+import type { Team } from '@/types/team'
+import type { Agent } from '@/types/agent'
+
+/** The 5 team-scoped titles that R12 requires for a functional team. */
+export const REQUIRED_TEAM_TITLES = [
+  'chief-of-staff',
+  'architect',
+  'orchestrator',
+  'integrator',
+  'member',
+] as const
+
+export interface TeamCompositionStatus {
+  /** True iff all 5 required titles are present among the team's agents. */
+  complete: boolean
+  /** Lower-case titles missing from the team, in the canonical order. */
+  missing: string[]
+}
+
+/**
+ * Checks whether a team satisfies R12 (all 5 required titles present).
+ *
+ * Pure function. Takes the team + the full agent list (both already
+ * resident in the client via `useSessions` / team registry hooks) so
+ * there is no extra fetch.
+ */
+export function checkTeamComposition(team: Team, agents: Agent[]): TeamCompositionStatus {
+  const teamAgentIds = new Set(team.agentIds || [])
+  const presentTitles = new Set<string>()
+  for (const agent of agents) {
+    if (!teamAgentIds.has(agent.id)) continue
+    const title = (agent.governanceTitle || 'autonomous').toLowerCase()
+    presentTitles.add(title)
+  }
+  const missing = REQUIRED_TEAM_TITLES.filter(t => !presentTitles.has(t))
+  return { complete: missing.length === 0, missing }
+}


### PR DESCRIPTION
## Summary

Surfaces R12 (team composition) violations on team cards in the sidebar. R12 is already enforced server-side (PG06 in element-management-service.ts), but it was invisible in the UI — users could not see which teams were missing required titles until something went wrong.

## Fix

1. New `lib/team-composition.ts` with a pure `checkTeamComposition(team, agents)` function and `REQUIRED_TEAM_TITLES` constant (the same 5 titles that PG06 checks: chief-of-staff, architect, orchestrator, integrator, member).
2. `components/sidebar/TeamCard.tsx` imports the function, memoizes the result against `agents` identity, and renders an amber badge with AlertTriangle icon + the text 'R12' next to the team name when composition is incomplete.
3. The badge tooltip lists the missing titles so the user knows what to fix.

## Design choices

- **Amber, not red**: a non-functional team is still recoverable — it needs attention, not alarm.
- **Client-side check**: server is still the authority (PG06); this is a display hint that may lag the server by one refetch cycle. Acceptable tradeoff.
- **Pure function**: easy to unit-test in a follow-up.

## Verification

- `npx tsc --noEmit`: PASS

## Diff stat

```
 components/sidebar/TeamCard.tsx |  20 +++++++++++-
 lib/team-composition.ts         |  51 +++++++++++++++++++++++++++++
 2 files changed, 70 insertions(+), 1 deletion(-)
```